### PR TITLE
Tools.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ Contact:
 e-mail: support@advancedhdrbook.com
 
 facebook: https://www.facebook.com/pages/Advanced-High-Dynamic-Range-Imaging-Book/166905003358276
+


### PR DESCRIPTION
The majority of TMOs return tone mapped images with linear values (i.e., withouth a CRF or gamma encoding). 
This means that gamma encoding needs to be applied to the output of these TMOs before visualization or before 
writing tone mapped images on the disk; otherwise these images will appear dark.
A few operators (e.g., Mertens et al.'s operator) return gamma encoded values,
so there is no need to apply gamma to them; in this case a message (e.g., a Warning) is displayed
after tone mapping alerting that there is no need of gamma encoding.